### PR TITLE
Comment Hard coded localization

### DIFF
--- a/src/main/java/fr/cnes/cubeExplorer/resources/fits/FitsCube.java
+++ b/src/main/java/fr/cnes/cubeExplorer/resources/fits/FitsCube.java
@@ -106,14 +106,14 @@ public class FitsCube extends AbstractDataCube {
             properties.put("metadata", getHeader().getMetadata(md));
             
             //TODO bouchon description
-            JSONObject localisation = new JSONObject();
-            localisation.put("name", "m31");
-            localisation.put("constellation", "andromeda");
-            JSONObject object_type = new JSONObject();
-            object_type.put("class", "star");
-            
-            properties.put("localisation", localisation);
-            properties.put("object_type", object_type);
+//            JSONObject localisation = new JSONObject();
+//            localisation.put("name", "m31");
+//            localisation.put("constellation", "andromeda");
+//            JSONObject object_type = new JSONObject();
+//            object_type.put("class", "star");
+//            
+//            properties.put("localisation", localisation);
+//            properties.put("object_type", object_type);
         }
         return properties;
     }

--- a/src/main/java/fr/cnes/cubeExplorer/resources/netcdf/NetcdfCube.java
+++ b/src/main/java/fr/cnes/cubeExplorer/resources/netcdf/NetcdfCube.java
@@ -91,15 +91,15 @@ public class NetcdfCube extends AbstractDataCube {
 			// toutes les metadata
 			properties.put("metadata", getHeader().getMetadata(md));
 			
-			//TODO bouchon description
-            JSONObject localisation = new JSONObject();
-            localisation.put("name", "m31");
-            localisation.put("constellation", "andromeda");
-            JSONObject object_type = new JSONObject();
-            object_type.put("class", "star");
-            
-            properties.put("localisation", localisation);
-            properties.put("object_type", object_type);
+//			//TODO bouchon description
+//            JSONObject localisation = new JSONObject();
+//            localisation.put("name", "m31");
+//            localisation.put("constellation", "andromeda");
+//            JSONObject object_type = new JSONObject();
+//            object_type.put("class", "star");
+//            
+//            properties.put("localisation", localisation);
+//            properties.put("object_type", object_type);
 		}
 		return properties;
 	}


### PR DESCRIPTION
I left the comment to help future implementation for those using this project as a kind of template.

As described in [redmine issue 2783](https://idoc-projets.ias.u-psud.fr/redmine/issues/2783?issue_count=18&issue_position=3&next_issue_id=2779&prev_issue_id=2784) and DataCube [Pull request 12](https://github.com/MizarWeb/DataCube/pull/12). The "Localization" and "Type Object" are hardcoded and always return the same information. 

I understand that this has been coded for demonstration purposes but I think that even for a demo it would be better to have something dynamic with real examples.
There is no conventions for these infos in fits or netcdf to implement a generic feature. 
If one find files that would work with an implementation of that feature we could have it work again depending on the occurrence of a specific metadata. 

----
Plus I think it should be "Location" and not "Localisation" that is spelled incorrectly in english ("Localization") and "Object Type" instead of "Type Object". I'll be sending a PR fixing that soon. 

Location = a particular place or position.
Localization = the process of making something local in character or restricting it to a particular place.